### PR TITLE
Fix issue #14: Add support for executing a script on reload/install

### DIFF
--- a/mclab.h
+++ b/mclab.h
@@ -231,7 +231,9 @@ extern char log_last_message[128];	/* last logged message     */
 void smclog(int severity, int code, const char *fmt, ...);
 
 /* parse-conf.c */
-int parse_conf_file(const char *file);
+int  run_callback    (char *cmd, mroute4_t *mroute);
+int  parse_conf_file (const char *file);
+void free_conf       (void);
 
 /* pidfile.c */
 int pidfile(const char *basename);

--- a/smcroute.8
+++ b/smcroute.8
@@ -1,4 +1,4 @@
-.Dd $Mdocdate: November 01 2011 $
+.Dd $Mdocdate: October 29 2015 $
 .Dt SMCROUTE 8 SMM
 .Os
 .Sh NAME
@@ -189,6 +189,24 @@ command line option.
 #
 # smcroute.conf example
 #
+
+# The exec command allows for executing a script, either on start/reload
+# and/or when matching a source-less (ANY) rule.  Leave out the 'on' arg
+# to allow the script to be called both when all static rules have been
+# installed *and* every time a dynamic rule is installed.
+#
+# When a source-less rule is matched the script can read the multicast
+# group and source address from the environment variables $source and
+# $group.  When the script is called at start/reload those environment
+# variables are unset, which can be used by the script to detect for
+# which case it is being called.
+#
+# Syntax:
+#   exec /path/to/script [optional params] [on <reload | install>]
+#
+# Example:
+#exec conntrack -F
+
 # The configuration file supports joining multicast groups, to use
 # Layer-2 signaling so that switches and routers open up multicast
 # traffic to your interfaces.  Leave is not supported, remove the

--- a/smcroute.c
+++ b/smcroute.c
@@ -43,6 +43,7 @@ int do_debug_logging = 0;
 
 static int         running   = 1;
 static const char *conf_file = SMCROUTE_SYSTEM_CONF;
+extern char       *exec_install;
 
 extern char *__progname;
 static const char version_info[] =
@@ -120,6 +121,7 @@ static void clean(void)
 {
 	mroute4_disable();
 	mroute6_disable();
+	free_conf();
 	ipc_exit();
 	smclog(LOG_NOTICE, 0, "Exiting.");
 }
@@ -130,6 +132,7 @@ static void restart(void)
 	mroute6_disable();
 	mcgroup4_disable();
 	mcgroup6_disable();
+	free_conf();
 	/* No need to close the IPC, only at cleanup. */
 
 	/* Update list of interfaces and create new virtual interface mappings in kernel. */
@@ -188,9 +191,9 @@ static int read_mroute4_socket(void)
 		}
 
 		/* Find any matching route for this group on that iif. */
-		mroute4_dyn_add(&mroute);
-
-		/* TODO: Add external callback script here, and/or call to conntrack -F */
+		result = mroute4_dyn_add(&mroute);
+		if (!result && exec_install)
+			run_callback(exec_install, &mroute);
 	}
 
 	return result;

--- a/smcroute.conf
+++ b/smcroute.conf
@@ -1,6 +1,24 @@
 #
 # smcroute.conf example
 #
+
+# The exec command allows for executing a script, either on start/reload
+# and/or when matching a source-less (ANY) rule.  Leave out the 'on' arg
+# to allow the script to be called both when all static rules have been
+# installed *and* every time a dynamic rule is installed.
+#
+# When a source-less rule is matched the script can read the multicast
+# group and source address from the environment variables $source and
+# $group.  When the script is called at start/reload those environment
+# variables are unset, which can be used by the script to detect for
+# which case it is being called.
+#
+# Syntax:
+#   exec /path/to/script [optional params] [on <reload | install>]
+#
+# Example:
+#exec conntrack -F
+
 # The configuration file supports joining multicast groups, to use
 # Layer-2 signaling so that switches and routers open up multicast
 # traffic to your interfaces.  Leave is not supported, remove the


### PR DESCRIPTION
This patch adds support for calling an external script 'on reload'
and/or 'on install' of (dynamic) source-less multicast routes.

The syntax for `/etc/smcroute.conf` looks as follows:

    exec /path/to/script [optional params] [on <reload | install>]

The 'on reload' condition is executed when SMCRoute has started up and
installed all static rules.  The 'on install' condition is for when a
new source-less rule is triggered.

The command can be given in many different forms, even on multiple
lines.  If the same line is repeated only the last line, for a given
condition, is used.  It is possible to use the same script both when
SMCRoute signals that all static routes have been installed and when
SMCRoute signals a single source-less rule have been triggered.  In
the latter case SMCRoute sets two environment variables ("source"
and "group"), which the script can use to distinguish between the
two use-cases.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>