### PR TITLE
Fix issue #14: Add support for executing a script on reload/install

### DIFF
--- a/ipc.c
+++ b/ipc.c
@@ -50,7 +50,7 @@ int ipc_server_init(void)
 	if (server_sd >= 0)
 		close(server_sd);
 
-	server_sd = socket(AF_UNIX, SOCK_STREAM, 0);
+	server_sd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 	if (server_sd < 0)
 		return -1;
 
@@ -89,7 +89,7 @@ int ipc_client_init(void)
 	if (client_sd >= 0)
 		close(client_sd);
 
-	client_sd = socket(AF_UNIX, SOCK_STREAM, 0);
+	client_sd = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 	if (client_sd < 0)
 		return -1;
 

--- a/mcgroup.c
+++ b/mcgroup.c
@@ -41,7 +41,7 @@ static struct iface *find_valid_iface(const char *ifname, int cmd)
 static void mcgroup4_init(void)
 {
 	if (mcgroup4_socket < 0) {
-		mcgroup4_socket = socket(AF_INET, SOCK_DGRAM, 0);
+		mcgroup4_socket = socket(AF_INET, SOCK_DGRAM | SOCK_CLOEXEC, 0);
 		if (mcgroup4_socket < 0)
 			smclog(LOG_ERR, errno, "Failed creating IPv4 socket for communicating group membership to kernel");
 	}
@@ -112,7 +112,7 @@ static int mcgroup6_socket = -1;
 static void mcgroup6_init(void)
 {
 	if (mcgroup6_socket < 0) {
-		mcgroup6_socket = socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+		mcgroup6_socket = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
 		if (mcgroup6_socket < 0)
 			smclog(LOG_WARNING, errno, "socket failed");
 	}

--- a/mclab.h
+++ b/mclab.h
@@ -231,6 +231,7 @@ extern char log_last_message[128];	/* last logged message     */
 void smclog(int severity, int code, const char *fmt, ...);
 
 /* parse-conf.c */
+int run_script(mroute_t *mroute);
 int parse_conf_file(const char *file);
 
 /* pidfile.c */

--- a/mroute-api.c
+++ b/mroute-api.c
@@ -98,7 +98,7 @@ int mroute4_enable(void)
 	unsigned int i;
 	struct iface *iface;
 
-	mroute4_socket = socket(AF_INET, SOCK_RAW, IPPROTO_IGMP);
+	mroute4_socket = socket(AF_INET, SOCK_RAW | SOCK_CLOEXEC, IPPROTO_IGMP);
 	if (mroute4_socket < 0) {
 		if (ENOPROTOOPT == errno)
 			smclog(LOG_WARNING, 0, "Kernel does not support IPv4 multicast routing, skipping ...");
@@ -441,7 +441,7 @@ int mroute6_enable(void)
 	unsigned int i;
 	struct iface *iface;
 
-	if ((mroute6_socket = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6)) < 0) {
+	if ((mroute6_socket = socket(AF_INET6, SOCK_RAW | SOCK_CLOEXEC, IPPROTO_ICMPV6)) < 0) {
 		if (ENOPROTOOPT == errno)
 			smclog(LOG_WARNING, 0, "Kernel does not support IPv6 multicast routing, skipping ...");
 

--- a/parse-conf.c
+++ b/parse-conf.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 #ifndef UNITTEST
 #include "mclab.h"
 #endif
@@ -30,6 +31,14 @@ extern char *script_exec;
 
 int run_script(mroute_t *mroute)
 {
+	int status;
+	pid_t pid;
+	char *argv[] = {
+		script_exec,
+		"reload",
+		NULL,
+	};
+
 	if (!script_exec)
 		return 0;
 
@@ -46,9 +55,20 @@ int run_script(mroute_t *mroute)
 
 		setenv("source", source, 1);
 		setenv("group", group, 1);
+		argv[1] = "install";
+	} else {
+		unsetenv("source");
+		unsetenv("group");
 	}
 
-	return WIFEXITED(system(script_exec));
+	pid = fork();
+	if (-1 == pid)
+		return 1;
+	if (0 == pid)
+		_exit(execv(argv[0], argv));
+	waitpid(pid, &status, 0);
+
+	return WIFEXITED(status);
 }
 
 static char *pop_token(char **line)
@@ -335,8 +355,10 @@ int parse_conf_file(const char *file)
 	free(linebuf);
 	fclose(fp);
 
-	if (script_exec)
-		run_script(NULL);
+	if (script_exec) {
+		if (run_script(NULL))
+			smclog(LOG_WARNING, 0, "Failed calling %s after (re)load of configuraion file.", script_exec);
+	}
 
 	return 0;
 }

--- a/smcroute.8
+++ b/smcroute.8
@@ -1,4 +1,4 @@
-.Dd $Mdocdate: November 01 2011 $
+.Dd $Mdocdate: October 29 2015 $
 .Dt SMCROUTE 8 SMM
 .Os
 .Sh NAME
@@ -50,6 +50,11 @@ flags, however, are accepted, but not command flags.
 .It Fl f Ar FILE
 Specify an alternative configuration file, instead of the default
 .Pa /etc/smcroute.conf .
+.It Fl s Ar SCRIPT
+Specify external script to be called when
+.Nm
+has loaded/reloaded all static multicast routes from the configuration
+file, or when a source-less (ANY) rule has been installed.
 .It Fl v
 Display version and enable verbose logs.  This gives a more verbose
 output in some error situations.  Do not expect too much, see syslog
@@ -73,7 +78,28 @@ option. The
 option will terminate a running daemon.  The 
 .Fl f Ar FILE
 option can be used to tell the daemon to setup routes from a conf
-file. By default it looks for /etc/smcroute.conf
+file. By default it looks for /etc/smcroute.conf.  The
+.Fl s Ar SCRIPT
+option is useful if you want to either trigger other processes to start
+when
+.Nm
+has completed installing routes from
+.Pa /etc/smcroute.conf ,
+or when a source-less (ANY) route from
+.Pa /etc/smcroute.conf .
+is matched and installed.  In the latter case
+.Nm
+calls the SCRIPT with two environment variables set:
+.Nm source ,
+and
+.Nm group .
+On startup/reload (SIGHUP) the environment variables are not set, only
+when a source-less rule is installed.  Be aware that these environment
+variables are unconditionally overwritten by
+.Nm
+and can thus not be used to pass information to the script from outside
+of
+.Nm .
 .Sh COMMANDS
 The following are commands that can only be passed to an already running daemon.
 .Bl -tag -width Ds

--- a/smcroute.c
+++ b/smcroute.c
@@ -40,6 +40,7 @@
 #define SMCROUTE_SYSTEM_CONF "/etc/smcroute.conf"
 
 int do_debug_logging = 0;
+const char *script_exec = NULL;
 
 static int         running   = 1;
 static const char *conf_file = SMCROUTE_SYSTEM_CONF;
@@ -58,6 +59,9 @@ static const char usage_info[] =
 	"  -d       Start daemon\n"
 	"  -n       Run daemon in foreground\n"
 	"  -f FILE  File to use instead of default " SMCROUTE_SYSTEM_CONF "\n"
+	"  -s SCRIPT  Script to call on startup/reload when all routes have\n"
+	"             been installed. Or when a source-less (ANY) route has\n"
+	"             been installed.\n"
 	"  -k       Kill a running daemon\n"
 	"\n"
 	"  -h       This help text\n"
@@ -190,9 +194,14 @@ static int read_mroute4_socket(void)
 		}
 
 		/* Find any matching route for this group on that iif. */
-		mroute4_dyn_add(&mroute);
+		result = mroute4_dyn_add(&mroute);
+		if (!result && script_exec) {
+			mroute_t mrt;
 
-		/* TODO: Add external callback script here, and/or call to conntrack -F */
+			mrt.version = 4;
+			mrt.u.mroute4 = mroute;
+			run_script(&mrt);
+		}
 	}
 
 	return result;
@@ -537,6 +546,12 @@ int main(int argc, const char *argv[])
 			conf_file = argv[1];
 			continue;
 
+		case 's':
+			if (num_opts != 2)
+				return usage();
+			script_exec = argv[1];
+			continue;
+
 		case 'D':
 			do_debug_logging = 1;
 			continue;
@@ -565,6 +580,11 @@ int main(int argc, const char *argv[])
 		if (geteuid() != 0) {
 			smclog(LOG_ERR, 0, "Need root privileges to start %s", __progname);
 			return 1;
+		}
+
+		if (script_exec && access(script_exec, X_OK)) {
+			fprintf(stderr, "%s is not an executable, disabling script.", script_exec);
+			script_exec = NULL;
 		}
 
 		start_server(background);

--- a/smcroute.c
+++ b/smcroute.c
@@ -200,7 +200,8 @@ static int read_mroute4_socket(void)
 
 			mrt.version = 4;
 			mrt.u.mroute4 = mroute;
-			run_script(&mrt);
+			if (run_script(&mrt))
+				smclog(LOG_WARNING, 0, "Failed calling %s with a new multicast route.", script_exec);
 		}
 	}
 
@@ -583,8 +584,8 @@ int main(int argc, const char *argv[])
 		}
 
 		if (script_exec && access(script_exec, X_OK)) {
-			fprintf(stderr, "%s is not an executable, disabling script.", script_exec);
-			script_exec = NULL;
+			smclog(LOG_ERR, 0, "%s is not an executable, exiting.", script_exec);
+			return 1;
 		}
 
 		start_server(background);


### PR DESCRIPTION
This patch adds support for calling an external script at startup and
reload (SIGHUP) as well as when (dynamic) source-less multicast routes
are installed.

    ./smcroute -s /path/to/script

The script is called when SMCRoute has started up, or has received
SIGHUP and just reloaded the configuration file, and when a new
source-less rule have been installed.

The script is called without command line arguments but with up to
two environement variables set:

- source: The source IP address of the multicast group sender
- group:  The IP multicast group address

The environment variables are only set when a "source-less" route is
installed in the kernel.

To protect the communication between SMCRoute and the kernel all files
and sockets are opened with CLOEXEC set.  So when the script runs it
does not have access to any file descriptors or sockets from SMCRoute.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>