### PR TITLE
Resolve #43: Run daemon as specific user and group

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ sbin_PROGRAMS		= smcroute
 smcroute_SOURCES	= smcroute.c mroute-api.c ifvc.c cmdpkt.c ipc.c	\
 			  mcgroup.c  parse-conf.c log.c pidfile.c mclab.h
 DISTCLEANFILES		= *~ DEADJOE semantic.cache *.gdb *.elf core core.* *.d
+LIBS			= -lcap
 
 ## Generate detached signature file (ascii-armored), like OpenVPN does
 GPG = gpg


### PR DESCRIPTION
smcroute daemon starts with root privileges. After startup procedure
it will try to change UID and GID to user and group specified with
command-line argument -p. It assumes that the user and group exists,
otherwise it will just print error message and continue running the
daemon as root.

NOTE: smcroute now depends on library libcap.