### PR TITLE
Fix #50: Add support for (*, GROUP/LEN) rules

### DIFF
--- a/cmdpkt.c
+++ b/cmdpkt.c
@@ -124,14 +124,13 @@ const char *cmd_convert_to_mroute(struct mroute *mroute, const struct cmd *packe
 		if (packet->cmd == 'a' || packet->count > 2)
 			arg += strlen(arg) + 1;
 
-		if (strchr(arg, ':') != NULL) {
+		if (strchr(arg, ':')) {
 			mroute->version = 6;
 			return cmd_convert_to_mroute6(&mroute->u.mroute6, packet);
-		} else {
-			mroute->version = 4;
-			return cmd_convert_to_mroute4(&mroute->u.mroute4, packet);
 		}
-		break;
+
+		mroute->version = 4;
+		return cmd_convert_to_mroute4(&mroute->u.mroute4, packet);
 
 	default:
 		return "Invalid command";

--- a/cmdpkt.c
+++ b/cmdpkt.c
@@ -184,6 +184,10 @@ const char *cmd_convert_to_mroute4(struct mroute4 *mroute, const struct cmd *pac
 	if (!*arg || (inet_pton(AF_INET, arg, &mroute->group) <= 0) || !IN_MULTICAST(ntohl(mroute->group.s_addr)))
 		return "Invalid multicast group";
 
+	/* adjust arg if we just parsed a GROUP/LEN argument */
+	if (ptr)
+		arg = ptr;
+
 	/*
 	 * Scan output interfaces for the 'add' command only, just ignore it
 	 * for the 'remove' command to be compatible to the first release.

--- a/mclab.h
+++ b/mclab.h
@@ -147,8 +147,10 @@ struct mroute4 {
 
 	struct in_addr sender;
 	struct in_addr group;           /* multicast group */
-	short inbound;                  /* incoming VIF    */
-	uint8 ttl[MAX_MC_VIFS];         /* outgoing VIFs   */
+	short          len;		/* prefix len, or 0:disabled */
+
+	short          inbound;         /* incoming VIF    */
+	uint8          ttl[MAX_MC_VIFS];/* outgoing VIFs   */
 };
 typedef struct mroute4 mroute4_t;
 

--- a/parse-conf.c
+++ b/parse-conf.c
@@ -190,7 +190,8 @@ static int join_mgroup_ssm(int lineno, char *ifname, char *group, char *source)
 
 static int add_mroute(int lineno, char *ifname, char *group, char *source, char *outbound[], int num)
 {
-	int i, total, result;
+	int i, total, ret;
+	struct mroute4 mroute;
 
 	if (!ifname || !group || !outbound || !num) {
 		errno = EINVAL;
@@ -200,7 +201,7 @@ static int add_mroute(int lineno, char *ifname, char *group, char *source, char 
 	if (strchr(group, ':')) {
 #if !defined(HAVE_IPV6_MULTICAST_HOST) || !defined(HAVE_IPV6_MULTICAST_ROUTING)
 		WARN("Ignored, IPv6 disabled.");
-		result = 0;
+		return 0;
 #else
 		mroute6_t mroute;
 
@@ -240,60 +241,57 @@ static int add_mroute(int lineno, char *ifname, char *group, char *source, char 
 
 		if (!total) {
 			WARN("No valid outbound interfaces, skipping multicast route.");
-			result = 1;
-		} else {
-			result = mroute6_add(&mroute);
+			return 1;
 		}
+
+		return mroute6_add(&mroute);
 #endif
-	} else {
-		struct mroute4 mroute;
-
-		memset(&mroute, 0, sizeof(mroute));
-		mroute.inbound = iface_get_vif_by_name(ifname);
-		if (mroute.inbound < 0) {
-			WARN("Invalid inbound IPv4 interface: %s", ifname);
-			return 1;
-		}
-
-		if (!source) {
-			mroute.sender.s_addr = INADDR_ANY;
-		} else if (inet_pton(AF_INET, source, &mroute.sender) <= 0) {
-			WARN("Invalid source IPv4 address: %s", source);
-			return 1;
-		}
-
-		if ((inet_pton(AF_INET, group, &mroute.group) <= 0) || !IN_MULTICAST(ntohl(mroute.group.s_addr))) {
-			WARN("Invalid IPv4 multicast group: %s", group);
-			return 1;
-		}
-
-		total = num;
-		for (i = 0; i < num; i++) {
-			struct iface *iface;
-
-			iface = iface_find_by_name(outbound[i]);
-			if (!iface || iface->vif == -1) {
-				total--;
-				WARN("Invalid outbound IPv4 interface: %s", outbound[i]);
-				continue; /* Try next, if any. */
-			}
-
-			if (iface->vif == mroute.inbound)
-				WARN("Same outbound IPv4 interface (%s) as inbound (%s)?", outbound[i], ifname);
-
-			/* Use a TTL threshold to indicate the list of outbound interfaces. */
-			mroute.ttl[iface->vif] = iface->threshold;
-		}
-
-		if (!total) {
-			WARN("No valid outbound IPv4 interfaces, skipping multicast route.");
-			result = 1;
-		} else {
-			result = mroute4_add(&mroute);
-		}
 	}
 
-	return result;
+	memset(&mroute, 0, sizeof(mroute));
+	mroute.inbound = iface_get_vif_by_name(ifname);
+	if (mroute.inbound < 0) {
+		WARN("Invalid inbound IPv4 interface: %s", ifname);
+		return 1;
+	}
+
+	if (!source) {
+		mroute.sender.s_addr = INADDR_ANY;
+	} else if (inet_pton(AF_INET, source, &mroute.sender) <= 0) {
+		WARN("Invalid source IPv4 address: %s", source);
+		return 1;
+	}
+
+	ret = inet_pton(AF_INET, group, &mroute.group);
+	if (ret <= 0 || !IN_MULTICAST(ntohl(mroute.group.s_addr))) {
+		WARN("Invalid IPv4 multicast group: %s", group);
+		return 1;
+	}
+
+	total = num;
+	for (i = 0; i < num; i++) {
+		struct iface *iface;
+
+		iface = iface_find_by_name(outbound[i]);
+		if (!iface || iface->vif == -1) {
+			total--;
+			WARN("Invalid outbound IPv4 interface: %s", outbound[i]);
+			continue; /* Try next, if any. */
+		}
+
+		if (iface->vif == mroute.inbound)
+			WARN("Same outbound IPv4 interface (%s) as inbound (%s)?", outbound[i], ifname);
+
+		/* Use a TTL threshold to indicate the list of outbound interfaces. */
+		mroute.ttl[iface->vif] = iface->threshold;
+	}
+
+	if (!total) {
+		WARN("No valid outbound IPv4 interfaces, skipping multicast route.");
+		return 1;
+	}
+
+	return mroute4_add(&mroute);
 }
 
 /**

--- a/smcroute.8
+++ b/smcroute.8
@@ -332,7 +332,7 @@ mroute from eth0 group 225.3.2.1 to eth1 eth2
 # The previous is an example of the (*,G) support.  Such rules cause
 # SMCRoute to dynamically add multicast routes to the kernel when the
 # first frame of a stream reaches the router.  It is also possible to
-# specify a range is such rules, again nnote that this currently only
+# specify a range of such rules, again, note that this currently only
 # works for IPv4.  Also, it is not possible to set a range of groups
 # to join atm.
 mroute from eth0 group 225.0.0.0/24 to eth1 eth2

--- a/smcroute.8
+++ b/smcroute.8
@@ -265,14 +265,16 @@ allows the integration of nodes that need static multicast routing into
 dynamic multicast routing domains.
 .Pp
 .Sh CONFIGURATION FILE
-From version 1.98.0 smcroute supports reading and setting up multicast
-routes from a config file. The default location is
+From version 1.98.0
+.Nm
+supports reading and setting up multicast routes from a config file. The
+default location is
 .Ar /etc/smcroute.conf ,
 but this can be overridden using the
 .Fl f Ar FILE
 command line option.
 .Pp
-.Bd -unfilled -offset left
+.Bd -unfilled -offset indent
 #
 # smcroute.conf example
 #

--- a/smcroute.8
+++ b/smcroute.8
@@ -168,6 +168,15 @@ and
 .Ar OUTIFNAME
 can be any network interface as listed by 'ifconfig' or 'ip link
 list' (incl. tunnel interfaces), but not the loopback interface.
+.Pp
+It is possible to add (*,G) routes with the client.  Set the
+.Ar SOURCE
+to
+.Ar 0.0.0.0 ,
+and if you want to specify a range, set
+.Ar GROUP/LEN ,
+e.g.
+.Ar 225.0.0.0/24 .
 .It Fl r Ar IFNAME SOURCE GROUP
 Remove a kernel multicast route.
 .It Fl j Ar IFNAME GROUP
@@ -289,12 +298,12 @@ command line option.
 #       maximum.  If you need more, you probably need to find another
 #       way of forwarding multicast to your router.
 #
-# Similarily supported is setting mroutes. Removing mroutes is not
+# Similarily supported is setting mroutes.  Removing mroutes is not
 # supported, remove/comment out the mroute or send a remove command.
 #
 # Syntax:
 #   phyint IFNAME <enable|disable> [ttl-threshold <1-255>]
-#   mgroup from IFNAME group MCGROUP
+#   mgroup from IFNAME group MCGROUP[/LEN]
 #   mroute from IFNAME [source ADDRESS] group MCGROUP to IFNAME [IFNAME ...]
 
 # This example disables the creation of a multicast VIF for WiFi
@@ -319,6 +328,15 @@ mroute from eth0 group 225.1.2.3 source 192.168.1.42 to eth1 eth2
 #       multicast.
 mgroup from eth0 group 225.3.2.1
 mroute from eth0 group 225.3.2.1 to eth1 eth2
+
+# The previous is an example of the (*,G) support.  Such rules cause
+# SMCRoute to dynamically add multicast routes to the kernel when the
+# first frame of a stream reaches the router.  It is also possible to
+# specify a range is such rules, again nnote that this currently only
+# works for IPv4.  Also, it is not possible to set a range of groups
+# to join atm.
+mroute from eth0 group 225.0.0.0/24 to eth1 eth2
+
 .Ed
 .Pp
 Fairly simple. As usual, to identify the origin of the inbound multicast

--- a/smcroute.8
+++ b/smcroute.8
@@ -304,6 +304,7 @@ command line option.
 # Syntax:
 #   phyint IFNAME <enable|disable> [ttl-threshold <1-255>]
 #   mgroup from IFNAME group MCGROUP[/LEN]
+#   ssmgroup from IFNAME group MCGROUP source SOURCE
 #   mroute from IFNAME [source ADDRESS] group MCGROUP to IFNAME [IFNAME ...]
 
 # This example disables the creation of a multicast VIF for WiFi
@@ -337,6 +338,10 @@ mroute from eth0 group 225.3.2.1 to eth1 eth2
 # to join atm.
 mroute from eth0 group 225.0.0.0/24 to eth1 eth2
 
+# The following example instructs the kernel to join the source
+# specific multicast group 225.2.1.3 on interface eth0 with
+# source 192.168.10.25.
+ssmgroup from eth0 group 225.2.1.3 source 192.168.10.25
 .Ed
 .Pp
 Fairly simple. As usual, to identify the origin of the inbound multicast

--- a/smcroute.conf
+++ b/smcroute.conf
@@ -56,6 +56,14 @@ mroute from virbr0 group 225.1.2.4 source 192.168.123.110 to eth0
 mgroup from eth0 group 225.3.2.1
 mroute from eth0 group 225.3.2.1 to eth1 eth2
 
+# The previous is an example of the (*,G) support.  Such rules cause
+# SMCRoute to dynamically add multicast routes to the kernel when the
+# first frame of a stream reaches the router.  It is also possible to
+# specify a range of such rules, again, note that this currently only
+# works for IPv4.  Also, it is not possible to set a range of groups
+# to join atm.
+mroute from eth0 group 225.0.0.0/24 to eth1 eth2
+
 # The following example instructs the kernel to join the source
 # specific multicast group 225.2.1.3 on interface eth0 with
 # source 192.168.10.25.


### PR DESCRIPTION
This patch set adds support for configuring multicast group ranges
as proposed in GitHub issue #50.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>
