### PR TITLE
Fix IPv4-only build

### DIFF
--- a/smcrouted.c
+++ b/smcrouted.c
@@ -174,6 +174,7 @@ static void read_mroute4_socket(void)
 }
 
 /* Receive and drop ICMPv6 stuff. This is either MLD packets or upcall messages sent up from the kernel. */
+#ifdef HAVE_IPV6_MULTICAST_ROUTING
 static void read_mroute6_socket(void)
 {
 	int result;
@@ -186,6 +187,7 @@ static void read_mroute6_socket(void)
 	if (result < 0)
 		smclog(LOG_INFO, "Failed clearing MLD message from kernel: %s", strerror(errno));
 }
+#endif
 
 /* Receive command from the smcroute client */
 static void read_ipc_command(void)


### PR DESCRIPTION
Building after "CFLAGS=-g ./configure --disable-ipv6" previously resulted in:

[...]
gcc -W -Wall -Wextra -g   -o smcrouted smcrouted-smcrouted.o smcrouted-mroute-api.o smcrouted-ifvc.o smcrouted-cmdpkt.o smcrouted-ipc.o smcrouted-mcgroup.o smcrouted-parse-conf.o smcrouted-log.o smcrouted-pidfile.o smcrouted-common.o
smcrouted-smcrouted.o: In function `read_mroute6_socket':
smcrouted.c:182: undefined reference to `mroute6_socket'
smcrouted.c:185: undefined reference to `mroute6_socket'
collect2: error: ld returned 1 exit status
[...]

```
This commit removes the reference to mroute6_socket if IPv6 is disabled.