### PR TITLE
Fix IPv4 network interface address identification

### DIFF
--- a/ifvc.c
+++ b/ifvc.c
@@ -59,8 +59,14 @@ void iface_init(void)
 
 	for (ifa = ifaddr; ifa && num_ifaces < MAX_IF; ifa = ifa->ifa_next) {
 		/* Check if already added? */
-		if (iface_find_by_name(ifa->ifa_name))
+		if ((iface = iface_find_by_name(ifa->ifa_name))) {
+			if (!iface->inaddr.s_addr && ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET)
+				/* If we know the interface but don't know an address
+				 * yet, remember this one.
+				 */
+				iface->inaddr = ((struct sockaddr_in *)ifa->ifa_addr)->sin_addr;
 			continue;
+		}
 
 		/* Copy data from interface iterator 'ifa' */
 		iface = &iface_list[num_ifaces++];


### PR DESCRIPTION
When iterating the list of system network interfaces, correctly determine
IPv4 addresses, even if getifaddrs() doesn't report the IPv4 address of an
interface first. Previously, if the IPv4 address was reported after another
address family's address, we ignored the IPv4 address completely. However,
on systems without VIFF_USE_IFINDEX defined, we rely on IPv4 addresses to
identify interfaces when creating VIFs, causing no VIFs to be created for
affected interfaces.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>