### PR TITLE
Support unlimited number of network interfaces

### DIFF
--- a/mclab.h
+++ b/mclab.h
@@ -119,8 +119,6 @@ extern int do_vifs;
 extern int do_syslog;
 
 /* ifvc.c */
-#define MAX_IF         40	// max. number of interfaces recognized
-
 void          iface_init            (void);
 void          iface_exit            (void);
 struct iface *iface_find_by_name    (const char *ifname);


### PR DESCRIPTION
Remove the limit on the number of system network interfaces (max. 40) that
may be handled by smcroute. Now the number of network interfaces is only
limited by the available RAM.

Note that this does not remove limit on the number of network interfaces
actually used for multicast routing as that is a kernel limit (typically
32 VIFs max.)

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>