### PR TITLE
Enable periodic (60s) dynamic route expiry by default

### DIFF
--- a/smcroute.8
+++ b/smcroute.8
@@ -85,7 +85,7 @@ different inbound interfaces if traffic arrives on several interfaces
 simultaneously.  In this case, the first selected inbound interface is
 retained until traffic on it ceases.
 .Pp
-See also the
+Defaults to 60s, set to 0 to disable.  See also the
 .Nm smcroutectl Ar flush
 command for another way of handling topology changes.
 .It Fl e Ar CMD

--- a/src/smcrouted.c
+++ b/src/smcrouted.c
@@ -50,7 +50,7 @@ int running    = 1;
 int background = 1;
 int do_vifs    = 1;
 int do_syslog  = 1;
-int cache_tmo  = 0;
+int cache_tmo  = 60;
 int interval   = MRDISC_INTERVAL_DEFAULT;
 int startup_delay = 0;
 


### PR DESCRIPTION
With expiration of only unused routes, periodic expiry should not cause
any harm (unnecessary MFC misses), so there's no good reason not to enable
it.  And with adding of MFC entries for any cache miss (even without
suitable dynamic routes), it's actually required to avoid filling the
cache with stale entries.

Signed-off-by: Martin Buck <mb-tmp-tvguho.pbz@gromit.dyndns.org>