### PR TITLE
Interface wildcard support

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -125,9 +125,11 @@ static int join_mgroup(int lineno, char *ifname, char *source, char *group)
 
 static int add_mroute(int lineno, char *ifname, char *group, char *source, char *outbound[], int num)
 {
-	int i, total, ret;
+	int i, total, ret, vif, result = 0;
 	char *ptr;
 	struct mroute4 mroute;
+	struct iface *iface;
+	struct ifmatch state_in, state_out;
 
 	if (!ifname || !group || !outbound || !num) {
 		errno = EINVAL;
@@ -140,109 +142,129 @@ static int add_mroute(int lineno, char *ifname, char *group, char *source, char 
 		return 0;
 #else
 		struct mroute6 mroute;
+		int mif;
 
-		memset(&mroute, 0, sizeof(mroute));
-		mroute.inbound = iface_get_mif_by_name(ifname);
-		if (mroute.inbound < 0) {
+		iface_match_init(&state_in);
+		while ((mif = iface_match_mif_by_name(ifname, &state_in, NULL)) >= 0) {
+			memset(&mroute, 0, sizeof(mroute));
+			mroute.inbound = mif;
+
+			if (!source || inet_pton(AF_INET6, source, &mroute.source.sin6_addr) <= 0) {
+				WARN("Invalid source IPv6 address: %s", source ?: "NONE");
+				return 1;
+			}
+
+			if (inet_pton(AF_INET6, group, &mroute.group.sin6_addr) <= 0 || !IN6_IS_ADDR_MULTICAST(&mroute.group.sin6_addr)) {
+				WARN("Invalid IPv6 multicast group: %s", group);
+				return 1;
+			}
+
+			total = 0;
+			for (i = 0; i < num; i++) {
+				iface_match_init(&state_out);
+				while ((mif = iface_match_mif_by_name(outbound[i], &state_out, &iface)) >= 0) {
+					if (mif == mroute.inbound) {
+						state_out.match_count--;
+						/* In case of wildcard matches, in==out is
+						 * quite normal, so don't complain
+						 */
+						if (!ifname_is_wildcard(ifname) && !ifname_is_wildcard(outbound[i]))
+							WARN("Same outbound IPv6 interface (%s) as inbound (%s)?", outbound[i], ifname);
+						continue;
+					}
+
+					/* Use a TTL threshold to indicate the list of outbound interfaces. */
+					mroute.ttl[mif] = iface->threshold;
+					total++;
+				}
+				if (!state_out.match_count)
+					WARN("Invalid outbound IPv6 interface: %s", outbound[i]);
+			}
+
+			if (!total) {
+				WARN("No valid outbound interfaces, skipping multicast route.");
+				result += 1;
+			} else {
+				result += mroute6_add(&mroute);
+			}
+		}
+
+		if (!state_in.match_count) {
 			WARN("Invalid inbound IPv6 interface: %s", ifname);
 			return 1;
 		}
-		if (!source || inet_pton(AF_INET6, source, &mroute.source.sin6_addr) <= 0) {
-			WARN("Invalid source IPv6 address: %s", source ?: "NONE");
-			return 1;
-		}
-
-		if (inet_pton(AF_INET6, group, &mroute.group.sin6_addr) <= 0 || !IN6_IS_ADDR_MULTICAST(&mroute.group.sin6_addr)) {
-			WARN("Invalid IPv6 multicast group: %s", group);
-			return 1;
-		}
-
-		total = num;
-		for (i = 0; i < num; i++) {
-			struct iface *iface;
-
-			iface = iface_find_by_name(outbound[i]);
-			if (!iface || iface->mif == -1) {
-				total--;
-				WARN("Invalid outbound IPv6 interface: %s", outbound[i]);
-				continue; /* Try next, if any. */
-			}
-
-			if (iface->mif == mroute.inbound)
-				WARN("Same outbound IPv6 interface (%s) as inbound (%s)?", outbound[i], ifname);
-
-			/* Use a TTL threshold to indicate the list of outbound interfaces. */
-			mroute.ttl[iface->mif] = iface->threshold;
-		}
-
-		if (!total) {
-			WARN("No valid outbound interfaces, skipping multicast route.");
-			return 1;
-		}
-
-		return mroute6_add(&mroute);
+		return result;
 #endif
 	}
 
-	memset(&mroute, 0, sizeof(mroute));
-	mroute.inbound = iface_get_vif_by_name(ifname);
-	if (mroute.inbound < 0) {
+	iface_match_init(&state_in);
+	while ((vif = iface_match_vif_by_name(ifname, &state_in, NULL)) >= 0) {
+		memset(&mroute, 0, sizeof(mroute));
+		mroute.inbound = vif;
+
+		if (!source) {
+			mroute.source.s_addr = htonl(INADDR_ANY);
+		} else if (inet_pton(AF_INET, source, &mroute.source) <= 0) {
+			WARN("Invalid source IPv4 address: %s", source);
+			return 1;
+		}
+
+		ptr = strchr(group, '/');
+		if (ptr) {
+			if (mroute.source.s_addr != htonl(INADDR_ANY)) {
+				WARN("GROUP/LEN not yet supported for source specific multicast.");
+				return 1;
+			}
+
+			*ptr++ = 0;
+			mroute.len = atoi(ptr);
+			if (mroute.len < 0 || mroute.len > 32) {
+				WARN("Invalid prefix length, %s/%d", group, mroute.len);
+				return 1;
+			}
+		}
+
+		ret = inet_pton(AF_INET, group, &mroute.group);
+		if (ret <= 0 || !IN_MULTICAST(ntohl(mroute.group.s_addr))) {
+			WARN("Invalid IPv4 multicast group: %s", group);
+			return 1;
+		}
+
+		total = 0;
+		for (i = 0; i < num; i++) {
+			iface_match_init(&state_out);
+			while ((vif = iface_match_vif_by_name(outbound[i], &state_out, &iface)) >= 0) {
+				if (vif == mroute.inbound) {
+					state_out.match_count--;
+					if (!ifname_is_wildcard(ifname) && !ifname_is_wildcard(outbound[i]))
+						/* In case of wildcard matches, in==out is
+						 * quite normal, so don't complain
+						 */
+						WARN("Same outbound IPv4 interface (%s) as inbound (%s)?", outbound[i], ifname);
+					continue;
+				}
+
+				/* Use a TTL threshold to indicate the list of outbound interfaces. */
+				mroute.ttl[vif] = iface->threshold;
+				total++;
+			}
+			if (!state_out.match_count)
+				WARN("Invalid outbound IPv4 interface: %s", outbound[i]);
+		}
+
+		if (!total) {
+			WARN("No valid outbound IPv4 interfaces, skipping multicast route.");
+			result += 1;
+		} else {
+			result += mroute4_add(&mroute);
+		}
+	}
+
+	if (!state_in.match_count) {
 		WARN("Invalid inbound IPv4 interface: %s", ifname);
 		return 1;
 	}
-
-	if (!source) {
-		mroute.source.s_addr = htonl(INADDR_ANY);
-	} else if (inet_pton(AF_INET, source, &mroute.source) <= 0) {
-		WARN("Invalid source IPv4 address: %s", source);
-		return 1;
-	}
-
-	ptr = strchr(group, '/');
-	if (ptr) {
-		if (mroute.source.s_addr != htonl(INADDR_ANY)) {
-			WARN("GROUP/LEN not yet supported for source specific multicast.");
-			return 1;
-		}
-
-		*ptr++ = 0;
-		mroute.len = atoi(ptr);
-		if (mroute.len < 0 || mroute.len > 32) {
-			WARN("Invalid prefix length, %s/%d", group, mroute.len);
-			return 1;
-		}
-	}
-
-	ret = inet_pton(AF_INET, group, &mroute.group);
-	if (ret <= 0 || !IN_MULTICAST(ntohl(mroute.group.s_addr))) {
-		WARN("Invalid IPv4 multicast group: %s", group);
-		return 1;
-	}
-
-	total = num;
-	for (i = 0; i < num; i++) {
-		struct iface *iface;
-
-		iface = iface_find_by_name(outbound[i]);
-		if (!iface || iface->vif == -1) {
-			total--;
-			WARN("Invalid outbound IPv4 interface: %s", outbound[i]);
-			continue; /* Try next, if any. */
-		}
-
-		if (iface->vif == mroute.inbound)
-			WARN("Same outbound IPv4 interface (%s) as inbound (%s)?", outbound[i], ifname);
-
-		/* Use a TTL threshold to indicate the list of outbound interfaces. */
-		mroute.ttl[iface->vif] = iface->threshold;
-	}
-
-	if (!total) {
-		WARN("No valid outbound IPv4 interfaces, skipping multicast route.");
-		return 1;
-	}
-
-	return mroute4_add(&mroute);
+	return result;
 }
 
 /*

--- a/src/ifvc.h
+++ b/src/ifvc.h
@@ -18,18 +18,27 @@ struct iface {
 	uint8_t threshold;	/* TTL threshold: 1-255, default: 1 */
 };
 
-void          iface_init            (void);
-void          iface_exit            (void);
+struct ifmatch {
+	unsigned int iter;
+	unsigned int match_count;
+};
 
-struct iface *iface_find_by_name    (const char *ifname);
-struct iface *iface_find_by_index   (unsigned int ifindex);
-struct iface *iface_find_by_vif     (int vif);
+void          iface_init              (void);
+void          iface_exit              (void);
 
-int           iface_get_vif         (struct iface *iface);
-int           iface_get_mif         (struct iface *iface);
+struct iface *iface_find_by_name      (const char *ifname);
+struct iface *iface_find_by_index     (unsigned int ifindex);
+struct iface *iface_find_by_vif       (int vif);
 
-int           iface_get_vif_by_name (const char *ifname);
-int           iface_get_mif_by_name (const char *ifname);
+void          iface_match_init        (struct ifmatch *state);
+struct iface *iface_match_by_name     (const char *ifname, struct ifmatch *state);
+int           ifname_is_wildcard      (const char *ifname);
+
+int           iface_get_vif           (struct iface *iface);
+int           iface_get_mif           (struct iface *iface);
+
+int           iface_match_vif_by_name (const char *ifname, struct ifmatch *state, struct iface **found);
+int           iface_match_mif_by_name (const char *ifname, struct ifmatch *state, struct iface **found);
 
 #endif /* SMCROUTE_IFVC_H_ */
 

--- a/src/mroute.c
+++ b/src/mroute.c
@@ -983,40 +983,46 @@ int mroute6_del(struct mroute6 *route)
 /* Used by file parser to add VIFs/MIFs after setup */
 int mroute_add_vif(char *ifname, uint8_t threshold)
 {
-	int ret;
+	int ret = 0;
 	struct iface *iface;
+	struct ifmatch state;
 
 	smclog(LOG_DEBUG, "Adding %s to list of multicast routing interfaces", ifname);
-	iface = iface_find_by_name(ifname);
-	if (!iface)
-		return 1;
-
-	iface->threshold = threshold;
-	ret = mroute4_add_vif(iface);
+	iface_match_init(&state);
+	while ((iface = iface_match_by_name(ifname, &state))) {
+		iface->threshold = threshold;
+		ret += mroute4_add_vif(iface);
 #ifdef HAVE_IPV6_MULTICAST_ROUTING
-	ret += mroute6_add_mif(iface);
+		ret += mroute6_add_mif(iface);
 #endif
+	}
 
-	return ret;
+	if (!state.match_count)
+		return 1;
+	else
+		return ret;
 }
 
 /* Used by file parser to remove VIFs/MIFs after setup */
 int mroute_del_vif(char *ifname)
 {
-	int ret;
+	int ret = 0;
 	struct iface *iface;
+	struct ifmatch state;
 
 	smclog(LOG_DEBUG, "Pruning %s from list of multicast routing interfaces", ifname);
-	iface = iface_find_by_name(ifname);
-	if (!iface)
-		return 1;
-
-	ret = mroute4_del_vif(iface);
+	iface_match_init(&state);
+	while ((iface = iface_match_by_name(ifname, &state))) {
+		ret += mroute4_del_vif(iface);
 #ifdef HAVE_IPV6_MULTICAST_ROUTING
-	ret += mroute6_del_mif(iface);
+		ret += mroute6_del_mif(iface);
 #endif
+	}
 
-	return ret;
+	if (!state.match_count)
+		return 1;
+	else
+		return ret;
 }
 
 static int show_mroute(int sd, struct mroute4 *r, int detail)

--- a/src/msg.c
+++ b/src/msg.c
@@ -111,78 +111,106 @@ static int is_range(char *arg)
 
 static int do_mroute4(struct ipc_msg *msg)
 {
-	int len, pos = 0;
-	struct mroute4 mroute;
-	struct in_addr src, grp;
+	struct ifmatch state_in;
+	int result = 0;
+	/* Only emit first non-fatal error message as that's the most relevant */
+	int errmsg = 0;
 
-	memset(&mroute, 0, sizeof(mroute));
-	mroute.inbound = iface_get_vif_by_name(msg->argv[pos++]);
-	if (mroute.inbound < 0) {
-		smclog(LOG_DEBUG, "Invalid input interface");
-		return 1;
-	}
+	iface_match_init(&state_in);
+	while (1) {
+		int len, pos = 0, vif;
+		struct mroute4 mroute;
+		struct ifmatch state_out;
+		struct in_addr src, grp;
+		char *ifname_in = msg->argv[pos++];
 
-	len = is_range(msg->argv[pos]);
-	if (inet_pton(AF_INET, msg->argv[pos++], &src) <= 0) {
-		smclog(LOG_DEBUG, "Invalid IPv4 source or group address");
-		return 1;
-	}
+		vif = iface_match_vif_by_name(ifname_in, &state_in, NULL);
+		if (vif < 0)
+			break;
+		memset(&mroute, 0, sizeof(mroute));
+		mroute.inbound = vif;
 
-	if (!IN_MULTICAST(ntohl(src.s_addr))) {
 		len = is_range(msg->argv[pos]);
-		if (inet_pton(AF_INET, msg->argv[pos++], &grp) <= 0 || !IN_MULTICAST(ntohl(grp.s_addr))) {
-			smclog(LOG_DEBUG, "Invalid IPv4 group address");
+		if (inet_pton(AF_INET, msg->argv[pos++], &src) <= 0) {
+			smclog(LOG_DEBUG, "Invalid IPv4 source or group address");
 			return 1;
 		}
 
-		if (len && (len < 0 || len > 32)) {
-			smclog(LOG_DEBUG, "Invalid prefix length (/LEN), must be 0-32");
-			return 1;
-		}
-	} else {
-		grp = src;
-		src.s_addr = htonl(INADDR_ANY);
-	}
-
-	mroute.source  = src;
-	mroute.len     = len;
-	mroute.group   = grp;
-
-	if (len && mroute.source.s_addr != htonl(INADDR_ANY)) {
-		smclog(LOG_DEBUG, "GROUP/LEN not yet supported for source specific multicast routes.");
-		return 1;
-	}
-
-	/*
-	 * Scan output interfaces for the 'add' command only, just
-	 * ignore it for the 'remove' command.
-	 */
-	if (msg->cmd == 'a') {
-		if (pos >= msg->count) {
-			smclog(LOG_DEBUG, "Missing outbound interface");
-			return 1;
-		}
-
-		while (pos < msg->count) {
-			int vif;
-			char *ifname = msg->argv[pos++];
-
-			vif = iface_get_vif_by_name(ifname);
-			if (vif < 0) {
-				smclog(LOG_DEBUG, "Invalid output interface");
+		if (!IN_MULTICAST(ntohl(src.s_addr))) {
+			len = is_range(msg->argv[pos]);
+			if (inet_pton(AF_INET, msg->argv[pos++], &grp) <= 0 || !IN_MULTICAST(ntohl(grp.s_addr))) {
+				smclog(LOG_DEBUG, "Invalid IPv4 group address");
 				return 1;
 			}
 
-			if (vif == mroute.inbound)
-				smclog(LOG_WARNING, "Same outbound interface as inbound %s?", ifname);
-
-			mroute.ttl[vif] = 1;	/* Use a TTL threshold */
+			if (len && (len < 0 || len > 32)) {
+				smclog(LOG_DEBUG, "Invalid prefix length (/LEN), must be 0-32");
+				return 1;
+			}
+		} else {
+			grp = src;
+			src.s_addr = htonl(INADDR_ANY);
 		}
 
-		return mroute4_add(&mroute);
+		mroute.source  = src;
+		mroute.len     = len;
+		mroute.group   = grp;
+
+		if (len && mroute.source.s_addr != htonl(INADDR_ANY)) {
+			smclog(LOG_DEBUG, "GROUP/LEN not yet supported for source specific multicast routes.");
+			return 1;
+		}
+
+		/*
+		 * Scan output interfaces for the 'add' command only, just
+		 * ignore it for the 'remove' command.
+		 */
+		if (msg->cmd == 'a') {
+			if (pos >= msg->count) {
+				smclog(LOG_DEBUG, "Missing outbound interface");
+				return 1;
+			}
+
+			int total = 0;
+			while (pos < msg->count) {
+				char *ifname_out = msg->argv[pos++];
+
+				iface_match_init(&state_out);
+				while ((vif = iface_match_vif_by_name(ifname_out, &state_out, NULL)) >= 0) {
+					if (vif == mroute.inbound) {
+						state_out.match_count--;
+						/* In case of wildcard matches, in==out is
+						 * quite normal, so don't complain
+						 */
+						if (!ifname_is_wildcard(ifname_in) && !ifname_is_wildcard(ifname_out) && !errmsg++)
+							smclog(LOG_WARNING, "Same outbound interface (%s) as inbound (%s)?", ifname_out, ifname_in);
+						continue;
+					}
+					mroute.ttl[vif] = 1;	/* Use a TTL threshold */
+					total++;
+				}
+
+				if (!state_out.match_count && !errmsg++)
+					smclog(LOG_DEBUG, "Invalid output interface");
+			}
+
+			if (!total) {
+				if (!errmsg++)
+					smclog(LOG_DEBUG, "No valid output interfaces");
+				result += 1;
+			} else {
+				result += mroute4_add(&mroute);
+			}
+		} else {
+			result += mroute4_del(&mroute);
+		}
 	}
 
-	return mroute4_del(&mroute);
+	if (!state_in.match_count) {
+		smclog(LOG_DEBUG, "Invalid input interface");
+		return 1;
+	}
+	return result;
 }
 
 static int do_mroute6(struct ipc_msg *msg)
@@ -192,57 +220,85 @@ static int do_mroute6(struct ipc_msg *msg)
 	smclog(LOG_WARNING, "IPv6 multicast support disabled.");
 	return 1;
 #else
-	int pos = 0;
-	struct mroute6 mroute;
+	struct ifmatch state_in;
+	int result = 0;
+	/* Only emit first non-fatal error message as that's the most relevant */
+	int errmsg = 0;
 
-	memset(&mroute, 0, sizeof(mroute));
-	mroute.inbound = iface_get_mif_by_name(msg->argv[pos++]);
-	if (mroute.inbound < 0) {
-		smclog(LOG_DEBUG, "Invalid input interface");
-		return 1;
-	}
+	iface_match_init(&state_in);
+	while (1) {
+		int pos = 0, mif;
+		struct mroute6 mroute;
+		struct ifmatch state_out;
+		char *ifname_in = msg->argv[pos++];
 
-	if (inet_pton(AF_INET6, msg->argv[pos++], &mroute.source.sin6_addr) <= 0) {
-		smclog(LOG_DEBUG, "Invalid IPv6 source address");
-		return 1;
-	}
+		mif = iface_match_mif_by_name(ifname_in, &state_in, NULL);
+		if (mif < 0)
+			break;
+		memset(&mroute, 0, sizeof(mroute));
+		mroute.inbound = mif;
 
-	if (inet_pton(AF_INET6, msg->argv[pos++], &mroute.group.sin6_addr) <= 0 ||
-	    !IN6_IS_ADDR_MULTICAST(&mroute.group.sin6_addr)) {
-		smclog(LOG_DEBUG, "Invalid IPv6 group address");
-		return 1;
-	}
-
-	/*
-	 * Scan output interfaces for the 'add' command only, just ignore it
-	 * for the 'remove' command to be compatible to the first release.
-	 */
-	if (msg->cmd == 'a') {
-		if (pos >= msg->count) {
-			smclog(LOG_DEBUG, "Missing outbound interface");
+		if (inet_pton(AF_INET6, msg->argv[pos++], &mroute.source.sin6_addr) <= 0) {
+			smclog(LOG_DEBUG, "Invalid IPv6 source address");
 			return 1;
 		}
 
-		while (pos < msg->count) {
-			int mif;
-			char *ifname = msg->argv[pos++];
+		if (inet_pton(AF_INET6, msg->argv[pos++], &mroute.group.sin6_addr) <= 0 ||
+		    !IN6_IS_ADDR_MULTICAST(&mroute.group.sin6_addr)) {
+			smclog(LOG_DEBUG, "Invalid IPv6 group address");
+			return 1;
+		}
 
-			mif = iface_get_mif_by_name(ifname);
-			if (mif < 0) {
-				smclog(LOG_DEBUG, "Invalid output interface");
+		/*
+		 * Scan output interfaces for the 'add' command only, just ignore it
+		 * for the 'remove' command to be compatible to the first release.
+		 */
+		if (msg->cmd == 'a') {
+			if (pos >= msg->count) {
+				smclog(LOG_DEBUG, "Missing outbound interface");
 				return 1;
 			}
 
-			if (mif == mroute.inbound)
-				smclog(LOG_DEBUG, "Same outbound interface as inbound %s?", ifname);
+			int total = 0;
+			while (pos < msg->count) {
+				char *ifname_out = msg->argv[pos++];
 
-			mroute.ttl[mif] = 1;	/* Use a TTL threshold */
+				iface_match_init(&state_out);
+				while ((mif = iface_match_mif_by_name(ifname_out, &state_out, NULL)) >= 0) {
+					if (mif == mroute.inbound) {
+						state_out.match_count--;
+						/* In case of wildcard matches, in==out is
+						 * quite normal, so don't complain
+						 */
+						if (!ifname_is_wildcard(ifname_in) && !ifname_is_wildcard(ifname_out) && !errmsg++)
+							smclog(LOG_WARNING, "Same outbound interface (%s) as inbound (%s)?", ifname_out, ifname_in);
+						continue;
+					}
+					mroute.ttl[mif] = 1;	/* Use a TTL threshold */
+					total++;
+				}
+
+				if (!state_out.match_count && !errmsg++)
+					smclog(LOG_DEBUG, "Invalid output interface");
+			}
+
+			if (!total) {
+				if (!errmsg++)
+					smclog(LOG_DEBUG, "No valid output interfaces");
+				result += 1;
+			} else {
+				result += mroute6_add(&mroute);
+			}
+		} else {
+			result += mroute6_del(&mroute);
 		}
-
-		return mroute6_add(&mroute);
 	}
 
-	return mroute6_del(&mroute);
+	if (!state_in.match_count) {
+		smclog(LOG_DEBUG, "Invalid input interface");
+		return 1;
+	}
+	return result;
 #endif
 }
 


### PR DESCRIPTION
Not really a pull request yet, more a request for comments.

This implements interface wildcard support. With it, you can abbreviate network interface names using an iptables-style "+"-suffix that matches anything. For example, you could use "phyint eth+" to match eth0, eth1, eth2, ethfoo123 etc,. or you could use "mroute from tun+ group 239.0.0.0 to tun+" (and the latter is clever enough not to route from tunX to tunY when X==Y).

Wildcards may be used anywhere instead of fixed interface names, i.e. in the config file in "phyint", "mroute" and "mgroup" statements and also when specifying interface names on the command line.

I'm using this on a VPN server with lots of dynamic tunnel interfaces with hard to predict interface names.

This change is pretty intrusive but I tried to implement it in such a way that I don't have to restructure all of smcroute. So intead of performing simple interface lookups, functions using interface names now instatiate an iterator and iterate internally.

It's for an ancient version of smcroute (2.1.0). If you think interface wildcard support is useful and if you're happy with the way I implemented it, I'll try to make it work with latest smcroute and I'll update this pull request. But I wanted to ask first before wasting lots of time...
