### PR TITLE
Fix buggy interface + VIF re-init on SIGHUP

### DIFF
--- a/src/ifvc.c
+++ b/src/ifvc.c
@@ -171,19 +171,23 @@ struct iface *iface_find_by_vif(int vif)
 }
 
 /**
- * iface_find_by_index - Find by kernel interface index
- * @ifindex: Kernel interface index
+ * iface_iterator - Interface iterator
+ * @first: Set to start from beginning
  *
  * Returns:
- * Pointer to a @struct iface of the requested interface, or %NULL if no
- * interface @ifindex exists.
+ * Pointer to a @struct iface, or %NULL when no more interfaces exist.
  */
-struct iface *iface_find_by_index(unsigned int ifindex)
+struct iface *iface_iterator(int first)
 {
-	if (ifindex >= num_ifaces)
+	static int i = 0;
+
+	if (first)
+		i = 0;
+
+	if (i >= num_ifaces)
 		return NULL;
 
-	return &iface_list[ifindex];
+	return &iface_list[i++];
 }
 
 

--- a/src/ifvc.h
+++ b/src/ifvc.h
@@ -21,8 +21,9 @@ struct iface {
 void          iface_init            (void);
 void          iface_exit            (void);
 
+struct iface *iface_iterator        (int first);
+
 struct iface *iface_find_by_name    (const char *ifname);
-struct iface *iface_find_by_index   (unsigned int ifindex);
 struct iface *iface_find_by_vif     (int vif);
 
 int           iface_get_vif         (struct iface *iface);

--- a/src/mroute.c
+++ b/src/mroute.c
@@ -193,7 +193,6 @@ static void cache_flush(void *arg)
 int mroute4_enable(int do_vifs, int table_id, int timeout)
 {
 	int arg = 1;
-	unsigned int i;
 	struct iface *iface;
 	static int running = 0;
 
@@ -240,10 +239,9 @@ int mroute4_enable(int do_vifs, int table_id, int timeout)
 	memset(&vif_list, 0, sizeof(vif_list));
 
 	/* Create virtual interfaces (VIFs) for all non-loopback interfaces supporting multicast */
-	for (i = 0; do_vifs && (iface = iface_find_by_index(i)); i++) {
-		/* No point in continuing the loop when out of VIF's */
-		if (mroute4_add_vif(iface))
-			break;
+	if (do_vifs) {
+		for (iface = iface_iterator(1); iface; iface = iface_iterator(0))
+			mroute4_add_vif(iface);
 	}
 
 	LIST_INIT(&mroute4_conf_list);
@@ -879,10 +877,9 @@ int mroute6_enable(int do_vifs, int table_id)
 	}
 #endif
 	/* Create virtual interfaces, IPv6 MIFs, for all non-loopback interfaces */
-	for (i = 0; do_vifs && (iface = iface_find_by_index(i)); i++) {
-		/* No point in continuing the loop when out of MIF's */
-		if (mroute6_add_mif(iface))
-			break;
+	if (do_vifs) {
+		for (iface = iface_iterator(1); iface; iface = iface_iterator(0))
+			mroute6_add_mif(iface);
 	}
 
 	return 0;


### PR DESCRIPTION
This patch refactors the iface_find_by_index() function into a proper
iterator, since that's what it's used for anyway.  Without this paatch
smcrouted loses track of interface indexes vs number of interfaces and
the resulting mess is no multicast VIFs created in the kernel.

Signed-off-by: Joachim Nilsson <troglobit@gmail.com>