### PR TITLE
Properly handle argv index while parsing command line params

### DIFF
--- a/src/smcroutectl.c
+++ b/src/smcroutectl.c
@@ -381,8 +381,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	while (optind < argc && !cmd) {
-		char *arg = argv[optind++];
+
+	pos = optind;
+	while (pos < argc && !cmd) {
+		char *arg = argv[pos];
 
 		for (i = 0; args[i].val; i++) {
 			int       c = args[i].val;
@@ -406,7 +408,7 @@ int main(int argc, char *argv[])
 
 			default:
 				cmd = &args[i];
-				if (argc - ++pos < args[i].min_args) {
+				if (argc - (pos + 1) < args[i].min_args) {
 					warnx("Not enough arguments to command %s", nm);
 					status = 1;
 					goto help;
@@ -416,6 +418,7 @@ int main(int argc, char *argv[])
 
 			break;	/* Next arg */
 		}
+		pos++;
 	}
 
 	if (help) {


### PR DESCRIPTION
This PR fixes argument parsing logic of `smcroutectl` by properly indexing argv elements.

Without this patch, calling:
```
./src/smcroutectl -d -I smcrouted add vlan1 ff12::8384 br-guests 
```
results in smcroutectl sending via socketpath a `ipc_msg` struct with `argv` objects set to:
```
smcrouted add vlan1 ff12::8384 br-guests
```
while on the other hand calling:
```
./src/smcroutectl -d add vlan1 ff12::8384 br-guests  -I smcrouted
```
results in smcroutectl sending via socketpath a `ipc_msg` struct with `argv objects set to:
```
add vlan1 ff12::8384 br-guests
```
As you can see neither of `argc` arrays is correct due to `smroutectl` including the subcommand or the subcommand and identification string in the `argc` array.

The fix makes the code actually update the `pos` variable with the index of the first argument after subcommand keyword (i.e. `add`, `remove`, etc...).
