### PR TITLE
Allow re-configuration of unprivileged smcrouted

### DIFF
--- a/src/mroute.h
+++ b/src/mroute.h
@@ -104,14 +104,14 @@ struct mroute {
 };
 
 int  mroute4_enable    (int do_vifs, int table_id, int timeout);
-void mroute4_disable   (void);
+void mroute4_disable   (int close_socket);
 int  mroute4_dyn_add   (struct mroute4 *mroute);
 void mroute4_dyn_expire(int max_idle);
 int  mroute4_add       (struct mroute4 *mroute);
 int  mroute4_del       (struct mroute4 *mroute);
 
 int  mroute6_enable    (int do_vifs, int table_id);
-void mroute6_disable   (void);
+void mroute6_disable   (int close_socket);
 int  mroute6_add       (struct mroute6 *mroute);
 int  mroute6_del       (struct mroute6 *mroute);
 

--- a/src/smcrouted.c
+++ b/src/smcrouted.c
@@ -69,8 +69,8 @@ static const char version_info[] = PACKAGE_NAME " v" PACKAGE_VERSION;
 /* Cleans up, i.e. releases allocated resources. Called via atexit() */
 static void clean(void)
 {
-	mroute4_disable();
-	mroute6_disable();
+	mroute4_disable(1);
+	mroute6_disable(1);
 	mcgroup4_disable();
 	mcgroup6_disable();
 	ipc_exit();
@@ -80,8 +80,8 @@ static void clean(void)
 
 static void restart(void)
 {
-	mroute4_disable();
-	mroute6_disable();
+	mroute4_disable(0);
+	mroute6_disable(0);
 	mcgroup4_disable();
 	mcgroup6_disable();
 	/* No need to close the IPC, only at cleanup. */


### PR DESCRIPTION
This patch allows an unprivileged smcrouted to reconfigure itself. SIGHUP will
no longer lead to closure of the IGMP socket. Instead, only the routes are
flushed and the socket is kept open for later re-use.