### PR TITLE
Added distribution build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ smcrouted
 smcroutectl
 smcroute.service
 stamp-h1
+*.tar.*
+.dirstamp


### PR DESCRIPTION
`make dist` generates files we don't need to commit.
Added them to .gitignore.