### PR TITLE
fix init script 'stop' command

### DIFF
--- a/smcroute.init
+++ b/smcroute.init
@@ -18,6 +18,7 @@
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/sbin/smcrouted
+DAEMONCTL=/usr/sbin/smcroutectl
 DAEMON_OPTS=
 NAME=smcrouted
 DESC="static multicast router daemon"
@@ -50,7 +51,7 @@ stop() {
 	local error
 	local result
 	log_begin_msg "Stopping $DESC: $NAME"
-	error=$($DAEMON -k 2>&1)
+	error=$($DAEMONCTL kill 2>&1)
 	result=$?
 	log_progress_msg ${error#ERRO: }
 	log_end_msg $result


### PR DESCRIPTION
I'm using `SMCRoute v2.4.2` (debian testing).

The init script does not stop the daemon, an error is reported instead:

```
# /etc/init.d/smcroute stop
Stopping static multicast router daemon: smcrouted /usr/sbin/smcrouted: invalid option -- 'k' 
```

I think one should use `smcroutectl `to stop the daemon.