### PR TITLE
Add log message when trying to delete a non-existing route

### DIFF
--- a/src/mroute.c
+++ b/src/mroute.c
@@ -833,6 +833,7 @@ int mroute4_del(struct mroute4 *route)
 			return do_mroute4_del(entry);
 		}
 
+		smclog(LOG_NOTICE, "Cannot delete multicast route: not found");
 		errno = ENOENT;
 		return -1;
 	}
@@ -861,6 +862,7 @@ int mroute4_del(struct mroute4 *route)
 		return ret;
 	}
 
+	smclog(LOG_NOTICE, "Cannot delete multicast route: not found");
 	errno = ENOENT;
 	return -1;
 }


### PR DESCRIPTION
When trying to delete a non existing route with smcroutectl the returned message is whatever content of log_message. Example:

Before:
> ~ # smcrouted -l debug
> ~ # smcroutectl add eth1 239.255.42.12 eth1
> ~ # smcroutectl add eth1 239.255.43.0/24 eth1
> ~ # smcroutectl remove eth1 239.255.42.13
> smcroutectl: Same outbound interface (eth1) as inbound (eth1) may cause routing loops.
> ~ # smcroutectl remove eth1 239.255.44.0/24
> smcroutectl: Same outbound interface (eth1) as inbound (eth1) may cause routing loops.

After:

> ~ # smcrouted -l debug
> ~ # smcroutectl add eth1 239.255.42.12 eth1
> ~ # smcroutectl add eth1 239.255.43.0/24 eth1
> ~ # smcroutectl remove eth1 239.255.42.13
> smcroutectl: Cannot delete multicast route: not found
> ~ # smcroutectl remove eth1 239.255.44.0/24
> smcroutectl: Cannot delete multicast route: not found

Signed-off-by: Alexander Vickberg <wickbergster@gmail.com>