### PR TITLE
[experimental] initial IPv6 multicast forwarding support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ dist_sbin_SCRIPTS       = smcroute
 dist_man8_MANS		= smcroute.8
 SYMLINKS                = smcrouted.8 smcroutectl.8
 doc_DATA		= README.md COPYING smcroute.conf
-EXTRA_DIST		= README.md AUTHORS ChangeLog.md autogen.sh smcroute.conf smcroute.init
+EXTRA_DIST		= README.md AUTHORS ChangeLog.md autogen.sh smcroute.conf smcroute.default smcroute.init
 
 if HAVE_SYSTEMD
 systemd_DATA            = smcroute.service

--- a/README.md
+++ b/README.md
@@ -205,10 +205,14 @@ Example `smcroute.conf`:
     mgroup from eth0 group 225.1.2.3
     mroute from eth0 group 225.1.2.3 to eth1 eth2
 
+    mroute from wpan0 source :: group :: to 65520 eth0
+
 or, from the command line:
 
     # smcroutectl join eth0 225.1.2.3
     # smcroutectl add  eth0 225.1.2.3 eth1 eth2
+
+    # smcroutectl add wpan0 :: :: 65472 eth0
 
 Also, see the `smcrouted -c SEC` option for periodic flushing of learned
 (*,G) rules, including the automatic blocking of unknown multicast, and

--- a/smcroute.conf
+++ b/smcroute.conf
@@ -68,3 +68,16 @@ mroute from eth0 group 225.3.2.1 to eth1 eth2
 # works for IPv4.  Also, it is not possible to set a range of groups
 # to join atm.
 mroute from eth0 group 225.0.0.0/24 to eth1 eth2
+
+# Here we allow routing of any multicast from interface 'wpan0' to interface
+# 'eth0' if scope of the destination is allowed.
+# Note: the first parameter after 'to' should be scope mask for (::, ::).
+# here the binary format of 65520 is as below, allow if the destination is of
+# scope higher than realm local (3);
+# +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+# | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 0 | 0 | 0 | 0 |
+# +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+#       |                       |           |   |   |   |   |   |
+#     global                   org          | admin |  link |  rsvd
+#                                         site    rsvd   interface local
+mroute from wpan0 source :: group :: to 65520 eth0

--- a/smcroute.default
+++ b/smcroute.default
@@ -1,0 +1,1 @@
+SMCROUTED_OPTS=-l info

--- a/smcroute.service.in
+++ b/smcroute.service.in
@@ -8,8 +8,9 @@ After=network-online.target
 Requires=network-online.target
 
 [Service]
-Type=notify
-ExecStart=@SBINDIR@/smcrouted -n -s
+Type=simple
+EnvironmentFile=@sysconfdir@/default/smcroute
+ExecStart=@SBINDIR@/smcrouted -n -s $SMCROUTED_OPTS
 ExecReload=@SBINDIR@/smcroutectl restart
 
 # Hardening settings

--- a/src/ifvc.c
+++ b/src/ifvc.c
@@ -416,6 +416,28 @@ int iface_match_mif_by_name(const char *ifname, struct ifmatch *state, struct if
 }
 
 /**
+ * iface_find_by_mif - Find by virtual interface index
+ * @mif: Virtual multicast interface index
+ *
+ * Returns:
+ * Pointer to a @struct iface of the requested interface, or %NULL if no
+ * interface matching @mif exists.
+ */
+struct iface *iface_find_by_mif(int mif)
+{
+	size_t i;
+
+	for (i = 0; i < num_ifaces; i++) {
+		struct iface *iface = &iface_list[i];
+
+		if (iface->mif >= 0 && iface->mif == mif)
+			return iface;
+	}
+
+	return NULL;
+}
+
+/**
  * Local Variables:
  *  indent-tabs-mode: t
  *  c-file-style: "linux"

--- a/src/ifvc.h
+++ b/src/ifvc.h
@@ -32,6 +32,7 @@ struct iface *iface_iterator          (int first);
 
 struct iface *iface_find_by_name      (const char *ifname);
 struct iface *iface_find_by_vif       (int vif);
+struct iface *iface_find_by_mif       (int mif);
 
 void          iface_match_init        (struct ifmatch *state);
 struct iface *iface_match_by_name     (const char *ifname, struct ifmatch *state);

--- a/src/smcroutectl.c
+++ b/src/smcroutectl.c
@@ -138,7 +138,7 @@ static int get_width(void)
 static void table_heading(char *argv[], size_t count, int detail)
 {
 	int len;
-	char line[90];
+	char line[110];
 	const char *g = "GROUP (S,G)", *i = "INBOUND";
 	const char *r = "ROUTE (S,G)", *o = "OUTBOUND", *p = "PACKETS", *b = "BYTES";
 
@@ -147,11 +147,11 @@ static void table_heading(char *argv[], size_t count, int detail)
 		return;
 
 	if (count && argv[0][0] == 'g')
-		snprintf(line, sizeof(line), "\e[7m%-34s %-16s", g, i);
+		snprintf(line, sizeof(line), "\e[7m%-50s %-16s", g, i);
 	else if (detail)
-		snprintf(line, sizeof(line), "\e[7m%-34s %-16s %10s %10s  %-8s", r, i, p, b, o);
+		snprintf(line, sizeof(line), "\e[7m%-50s %-16s %10s %10s  %-8s", r, i, p, b, o);
 	else
-		snprintf(line, sizeof(line), "\e[7m%-34s %-16s %-8s", r, i, o);
+		snprintf(line, sizeof(line), "\e[7m%-50s %-16s %-8s", r, i, o);
 
 	len = get_width() - (int)strlen(line) + 4;
 	fprintf(stderr, "%s%*s\n\e[0m", line, len < 0 ? 0 : len, "");

--- a/src/smcrouted.c
+++ b/src/smcrouted.c
@@ -91,7 +91,7 @@ static void restart(void)
 	/* Update list of interfaces and create new virtual interface mappings in kernel. */
 	iface_init();
 	mroute4_enable(do_vifs, table_id, cache_tmo);
-	mroute6_enable(do_vifs, table_id);
+	mroute6_enable(do_vifs, table_id, cache_tmo);
 }
 
 void reload(void)
@@ -180,7 +180,7 @@ static int start_server(void)
 	}
 
 	/*
-	 * Timer API needs to be initilized before mroute4_enable()
+	 * Timer API needs to be initilized before mroute4_enable()/mroute6_enable()
 	 */
 	timer_init();
 
@@ -195,7 +195,7 @@ static int start_server(void)
 		api--;
 	}
 
-	if (mroute6_enable(do_vifs, table_id)) {
+	if (mroute6_enable(do_vifs, table_id, cache_tmo)) {
 		if (errno == EADDRINUSE)
 			busy++;
 		api--;

--- a/src/util.h
+++ b/src/util.h
@@ -32,4 +32,6 @@ size_t strlcpy(char *dst, const char *src, size_t len);
 size_t strlcat(char *dst, const char *src, size_t dsize);
 #endif
 
+int is_range(char *arg);  // return perfix len after '/'
+
 #endif /* SMCROUTE_UTIL_H_ */


### PR DESCRIPTION
   This commit also introduces one new multicast forwarding rule
    which filters multicast traffic by the multicast scope of the
    destination when forwarding.

    Sample usage:
    1) add scope filter rule to forward multicast traffic from wpan0
    interface to eth0 interface if the destination scope is higher than
    admin local 65504 (0xffe0).

    $sudo smcroutectl add wpan0 :: :: 65504 eth0

    2) update the scope filter to only allow destination scope higher than
    site local 65472 (0xffc0).

    $sudo smcroutectl add wpan0 :: :: 65472 eth0

    3) remove the scope filter rule
    $sudo smcroutectl remove wpan0 :: :: eth0
