### PR TITLE
IPv6 source wildcard initial implementation

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -234,8 +234,8 @@ static int add_mroute(int lineno, char *ifname, char *group, char *source, char 
 				mroute.len = 0;
 			} else {
 				if (inet_pton(AF_INET6, group, &mroute.group.sin6_addr) <= 0 ||
-						!IN6_IS_ADDR_MULTICAST(&mroute.group.sin6_addr) ||
-						!IN6_IS_ADDR_UNSPECIFIED(&mroute.group.sin6_addr)) {
+						!(IN6_IS_ADDR_MULTICAST(&mroute.group.sin6_addr) ||
+						  IN6_IS_ADDR_UNSPECIFIED(&mroute.group.sin6_addr))) {
 					WARN("mroute: Invalid IPv6 multicast group: %s", group);
 					return 1;
 				}
@@ -251,6 +251,11 @@ static int add_mroute(int lineno, char *ifname, char *group, char *source, char 
 				if (mroute.len != 0)
 				{
 					WARN("mroute: Ignore IPv6 multicast group prefix length: %d", mroute.len);
+					mroute.len = 128;
+				}
+				else
+				{
+					// Assume missing prefix for specified address as 128
 					mroute.len = 128;
 				}
 

--- a/src/mroute.h
+++ b/src/mroute.h
@@ -114,6 +114,7 @@ void mroute4_dyn_expire(int max_idle);
 int  mroute4_add       (struct mroute4 *mroute);
 int  mroute4_del       (struct mroute4 *mroute);
 
+int  mroute6_dyn_add   (struct mroute6 *mroute);
 int  mroute6_add       (struct mroute6 *mroute);
 int  mroute6_del       (struct mroute6 *mroute);
 


### PR DESCRIPTION
I need an IPv6 wildcard multicast forwarding (discussed in #31) for my project very much.
I created an initial implementation. It's mostly copy-paste of IPv4 code modified to work with IPv6 addresses. Tested on a RPi router and seems to work correctly. At least I can forward site-local ICMPv6 echo :)
I'm not sure if the quality of the code is enough to pull it. I hope this PR can be a base for a more thoughtful solution.