### PR TITLE
Allow omission of "/PREFIX" for IPv6 addresses. 

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -125,8 +125,8 @@ static int join_mgroup(int lineno, char *ifname, char *source, char *group)
 
 		if (group) {
 			len = is_range(group);
-			if (len < 1 || len > 128) {
-				WARN("Invalid IPv6 group prefix length (1-128): %d", len);
+			if (len < 0 || len > 128) {
+				WARN("Invalid IPv6 group prefix length (0-128): %d", len);
 				return 1;
 			}
 			if (!len)

--- a/src/msg.c
+++ b/src/msg.c
@@ -114,8 +114,8 @@ static int do_mgroup6(struct ipc_msg *msg)
 	}
 
 	len = is_range(group);
-	if (len < 1 || len > 128) {
-		smclog(LOG_DEBUG, "Invalid IPv6 group prefix length (1-128): %d", len);
+	if (len < 0 || len > 128) {
+		smclog(LOG_DEBUG, "Invalid IPv6 group prefix length (0-128): %d", len);
 		return 1;
 	}
 	if (!len)


### PR DESCRIPTION
Hi,

I noticed that IPv6 prefixes are treated differently compared to IPv4 ones. This patch allows IPv6 prefixes to be omitted. Similar to IPv4, this case will be handled by the existing code like /128 for CLI and the config file. Or is there a particular reason that I am missing?

I am using this config file:
```
phyint eth0.0x2 enable
phyint eth0.0x3 enable
mgroup from eth0.0x2 group ff14::1
mroute from eth0.0x2 source fd00:0:0:2::10 group ff14::1 to eth0.0x3
```

Before, loading the config file did not work:
```
[root@dev1 smcroute]# ip netns exec r0 /home/dthiele/dev/smcroute/src/smcrouted -n -f /home/dthiele/dev/smcroute/test1_smcroute6.conf -N
smcroute[507]: SMCRoute v2.5.0-beta1
smcroute[507]: /home/dthiele/dev/smcroute/test1_smcroute6.conf: L03: Invalid IPv6 group prefix length (1-128): 0
smcroute[507]: Failed reading /home/dthiele/dev/smcroute/test1_smcroute6.conf: No such file or directory.
smcroute[507]: Ready, waiting for client request or kernel event.
```
After:
```
[root@dev1 smcroute]# ip netns exec r0 /home/dthiele/dev/smcroute/src/smcrouted -n -f /home/dthiele/dev/smcroute/test1_smcroute6.conf -N
smcroute[544]: SMCRoute v2.5.0-beta1
smcroute[544]: Ready, waiting for client request or kernel event.
```

Best regards,
Daniel