### PR TITLE
Fix ipv6 inet_pton() calls

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -125,8 +125,8 @@ static int join_mgroup(int lineno, char *ifname, char *source, char *group)
 
 		if (group) {
 			len = is_range(group);
-			if (len < 1 || len > 128) {
-				WARN("Invalid IPv6 group prefix length (1-128): %d", len);
+			if (len < 0 || len > 128) {
+				WARN("Invalid IPv6 group prefix length (0-128): %d", len);
 				return 1;
 			}
 			if (!len)

--- a/src/msg.c
+++ b/src/msg.c
@@ -107,7 +107,7 @@ static int do_mgroup6(struct ipc_msg *msg)
 
 	if (msg->count == 3) {
 		strlcpy(group, msg->argv[2], sizeof(group));
-		rc += inet_pton(AF_INET6, msg->argv[1], &src);
+		rc += inet_pton(AF_INET6, msg->argv[1], &src.sin6_addr);
 	} else {
 		strlcpy(group, msg->argv[1], sizeof(group));
 		rc += inet_pton(AF_INET6, "::", &src.sin6_addr);
@@ -121,7 +121,7 @@ static int do_mgroup6(struct ipc_msg *msg)
 	if (!len)
 		len = 128;
 
-	rc += inet_pton(AF_INET6, group, &grp);
+	rc += inet_pton(AF_INET6, group, &grp.sin6_addr);
 	if (rc < 2 || !IN6_IS_ADDR_MULTICAST(&grp.sin6_addr)) {
 		smclog(LOG_DEBUG, "Invalid IPv6 source or group address.");
 		return 1;

--- a/src/msg.c
+++ b/src/msg.c
@@ -114,8 +114,8 @@ static int do_mgroup6(struct ipc_msg *msg)
 	}
 
 	len = is_range(group);
-	if (len < 1 || len > 128) {
-		smclog(LOG_DEBUG, "Invalid IPv6 group prefix length (1-128): %d", len);
+	if (len < 0 || len > 128) {
+		smclog(LOG_DEBUG, "Invalid IPv6 group prefix length (0-128): %d", len);
 		return 1;
 	}
 	if (!len)


### PR DESCRIPTION
Hi,

I think the inet_pton() calls in do_mgroup6() are using "struct sockaddr_in6" instead of "struct in6_addr" as their argument. This pull requests fixes this. Only the CLI is affected.
Sorry, I just saw that I accidentally based this pull request on top of #138. So it contains both fixes :-/.

Before:
```
[root@dev1 smcroute]# ip netns exec r0 ./src/smcroutectl join eth0.0x2 fd00:0:0:2::10 ff14::1
smcroutectl: Invalid IPv6 source or group address.
[root@dev1 smcroute]#
```

After:
```
[root@dev1 smcroute]# ip netns exec r0 ./src/smcroutectl join eth0.0x2 fd00:0:0:2::10 ff14::1
[root@dev1 smcroute]#
```

Best regards,
Daniel