### PR TITLE
Add support for Systemd service type 'notify'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     packages:
       - tree
       - libcap-dev
+      - libsystemd-dev
   coverity_scan:
     project:
       name: "troglobit/smcroute"

--- a/configure.ac
+++ b/configure.ac
@@ -108,6 +108,17 @@ AS_IF([test "x$with_systemd" != "xno"],
      [AC_SUBST([systemddir], [$with_systemd])])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemd" != "xno"])
 
+have_libsystemd=no
+AS_IF([test "x$with_systemd" != "xno"],
+     [PKG_CHECK_MODULES(LIBSYSTEMD, libsystemd,
+         [AC_DEFINE(HAVE_LIBSYSTEMD, 1, [Enable libsystemd integration])
+         have_libsystemd=yes])]
+)
+AS_IF([test "x$have_libsystemd" = "xyes"],
+     [AC_SUBST([systemd_service_type], [notify])],
+     [AC_SUBST([systemd_service_type], [simple])])
+AM_CONDITIONAL([HAVE_LIBSYSTEMD], [test "x$have_libsystemd" = "xyes"])
+
 # Check if we need -lpthread (building statically) and -lrt (older GLIBC)
 # Unset cached values when retrying with -lpthread and reset LIBS for each API
 need_librt=no

--- a/smcroute.service.in
+++ b/smcroute.service.in
@@ -8,8 +8,9 @@ After=network-online.target
 Requires=network-online.target
 
 [Service]
-Type=simple
+Type=@systemd_service_type@
 ExecStart=@SBINDIR@/smcrouted -n -s
+NotifyAccess=main
 
 # Hardening settings
 NoNewPrivileges=true

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,3 +30,7 @@ if USE_DOTCONF
 smcrouted_SOURCES      += conf.c conf.h
 endif
 
+if HAVE_LIBSYSTEMD
+smcrouted_CFLAGS      += $(LIBSYSTEMD_CFLAGS)
+smcrouted_LDADD       += $(LIBSYSTEMD_LIBS)
+endif


### PR DESCRIPTION
By calling sd_notify() the smcroute daemon (smcrouted) can tell the systemd
service manager when it is fully up and running. This allows systemd to manage
services synchronously (i.e. use service type 'notify') so that dependent tasks
can rely on smcrouted being fully up and running.

This patch is already in use in Debian package smcroute/2.4.4-2.

Related Debian bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=924361