### PR TITLE
Compare inbound vif with the rule when adding dynamic IPv6 routing entry

### DIFF
--- a/src/mroute.c
+++ b/src/mroute.c
@@ -1283,6 +1283,10 @@ static int is_match6(struct mroute6 *rule, struct mroute6 *cand)
 {
 	int result;
 
+	if (rule->inbound != cand->inbound) {
+		return 0;
+	}
+
 	if (rule->len == 128 && cand->len == 128) {
 		result = (0 == memcmp(&rule->group.sin6_addr, &cand->group.sin6_addr, sizeof(struct in6_addr)));
 	}


### PR DESCRIPTION
This patch fixes a problem with IPv6 dynamic rule selection.

When smcroute configuration contained multiple wildcard IPv6 address mroute entries with the same destination address, but different input interface, the algorithm incorrectly selected the first entry to configure routing. Basically, the input interface field was ignored. This patches fixes this problem by checking input interface field when selecting rule to use for routing configuration.

Signed-off-by: Hubert Miś <hubert.mis@gmail.com>