### PR TITLE
fix systemd daemon type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,8 +113,8 @@ AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemd" != "xno"])
 
 AS_IF([test "x$with_libsystemd" != "xno"], [
 	AC_DEFINE([HAVE_LIBSYSTEMD], [1], [Define to 1 if you have libsystemd-dev])
-	AC_SUBST([DAEMON_TYPE], "Notify")], [
-	AC_SUBST([DAEMON_TYPE], "Simple")])
+	AC_SUBST([DAEMON_TYPE], "notify")], [
+	AC_SUBST([DAEMON_TYPE], "simple")])
 AM_CONDITIONAL([HAVE_LIBSYSTEMD], [test "x$with_libsystemd" != "xno"])
 
 # Check if we need -lpthread (building statically) and -lrt (older GLIBC)


### PR DESCRIPTION
systemd complains when parsing the unit: `/lib/systemd/system/smcroute.service:12: Failed to parse service type, ignoring: Notify`