### PR TITLE
IPC: daemon: add batch-mode support

### DIFF
--- a/src/ipc.h
+++ b/src/ipc.h
@@ -7,8 +7,9 @@
 int   ipc_init    (char *path);
 void  ipc_exit    (void);
 
-int   ipc_send    (int sd, char *buf, size_t len);
-void *ipc_receive (int sd, char *buf, size_t len);
+int     ipc_send   (int sd, const char *buf, size_t len);
+ssize_t ipc_receive(int sd, char *buf, size_t len, int first_call);
+int     ipc_parse  (const char *buf, size_t sz, void *msg_buf);
 
 #endif /* SMCROUTE_IPC_H_ */
 


### PR DESCRIPTION
Add support to read multiple commands from client and invoke them. Example of possible (but not yet implemented) usage of smcroutectl:

smcroutectl --batch - << EOF
join  eth0 225.1.2.3
add   eth0 192.168.1.42 225.1.2.3 eth1 eth2
rem   eth1 225.3.4.5 eth3
leave eth1 225.3.4.5
EOF

Signed-off-by: Alexey Smirnov <s.alexey@gmail.com>