### PR TITLE
Fix removing group config

### DIFF
--- a/src/mcgroup.c
+++ b/src/mcgroup.c
@@ -372,7 +372,7 @@ int mcgroup_action(int cmd, const char *ifname, inet_addr_t *source, int src_len
 	}
 
 	if (!cmd) {
-		TAILQ_REMOVE(&kern_list, mcg, link);
+		TAILQ_REMOVE(&conf_list, mcg, link);
 		free_mc_sock(mcg->sd);
 		free(mcg);
 	}


### PR DESCRIPTION
mcg belongs to conf_list, not kern_list
If we remove mcg in this way we will get strange effects on joining/leaving the same group.