### PR TITLE
change op due to wrong replacement.

### DIFF
--- a/src/kern.c
+++ b/src/kern.c
@@ -324,7 +324,7 @@ int kern_vif_del(struct iface *iface)
 static int kern_mroute4(int cmd, struct mroute *route)
 {
 	char origin[INET_ADDRSTRLEN], group[INET_ADDRSTRLEN];
-	int op = cmd ? MRT_ADD_MFC : MRT_DEL_MFC;
+	int op = cmd ? MRT_ADD_MFC_PROXY : MRT_DEL_MFC_PROXY;
 	struct mfcctl mfcc = { 0 };
 	size_t i;
 
@@ -546,7 +546,7 @@ int kern_mif_del(struct iface *iface)
 static int kern_mroute6(int cmd, struct mroute *route)
 {
 	char origin[INET_ADDRSTR_LEN], group[INET_ADDRSTR_LEN];
-	int op = cmd ? MRT6_ADD_MFC : MRT6_DEL_MFC;
+	int op = cmd ? MRT6_ADD_MFC_PROXY : MRT6_DEL_MFC_PROXY;
 	struct mf6cctl mf6cc = { 0 };
 	size_t i;
 

--- a/test/same.sh
+++ b/test/same.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Verifies SIGHUP/reload functionality
+# XXX: add group verification as well
+#set -x
+
+. "$(dirname "$0")/lib.sh"
+
+print "Creating world ..."
+topo plus
+ip addr add 10.0.0.1/24 dev a1
+ip addr add  fc00::1/64 dev a1
+ip addr add 20.0.0.2/24 dev a2
+ip addr add  fc00::2/64 dev a2
+ip addr add 30.0.0.1/24 dev b1
+ip -br a
+
+print "Creating config #1 ..."
+cat <<EOF > "/tmp/$NM/conf"
+phyint a1 enable
+phyint a2 enable
+phyint b1 enable
+
+mgroup from a1 source 10.0.0.1 group 225.3.2.1
+mroute from a1 source 10.0.0.1 group 225.3.2.1 to b1
+
+mgroup from a2 source 10.0.0.1 group 225.3.2.1
+mroute from a2 source 10.0.0.1 group 225.3.2.1 to b1
+
+mgroup from a1 source fc00::3 group ff04:0:0:0:0:0:0:114
+mroute from a1 source fc00::3 group ff04:0:0:0:0:0:0:114 to b1
+
+mgroup from a2 source fc00::3 group ff04:0:0:0:0:0:0:114
+mroute from a2 source fc00::3 group ff04:0:0:0:0:0:0:114 to b1
+
+EOF
+cat "/tmp/$NM/conf"
+
+print "Starting smcrouted ..."
+../src/smcrouted -f "/tmp/$NM/conf" -N -n -P "/tmp/$NM/pid" -l debug -u "/tmp/$NM/sock" &
+sleep 1
+
+cat /proc/net/ip_mr_vif
+cat /proc/net/ip_mr_cache
+../src/smcroutectl -pu "/tmp/$NM/sock" show groups
+show_mroute
+ip mroute | grep -E "\(10.0.0.1,225.3.2.1\)\s+Iif: a1\s+Oifs: b1" \
+|| FAIL "Failed add IPv4 a1(S,G) -> b1 route"
+ip mroute | grep -E "\(10.0.0.1,225.3.2.1\)\s+Iif: a2\s+Oifs: b1" \
+|| FAIL "Failed add IPv4 a2(S,G) -> b1 route"
+
+ip -6 mroute | grep -E "\(fc00::3,ff04::114\)\s+Iif: a1\s+Oifs: b1" \
+|| FAIL "Failed add IPv6 a1(S,G) -> b1 route"
+ip -6 mroute | grep -E "\(fc00::3,ff04::114\)\s+Iif: a2\s+Oifs: b1" \
+|| FAIL "Failed add IPv6 a2(S,G) -> b1 route"
+OK


### PR DESCRIPTION
Hi, all.
I found a bug. The static MC route was placed by other which had same (S,G) but with different NIC.
Config:
ens36: (192.168.3.21,225.0.0.1) => ens33
ens38: (192.168.3.21,225.0.0.1) => ens33

After config, only got the last one(ens38 => ens33).

In kernel code, I saw NIC info lost when using MRT_ADD_MFC/MRT_DEL_MFC. Maybe MRT_ADD_MFC_PROXY/MRT_DEL_MFC_PROXY is a better choice.

I've changed code and added same.sh as UT, it was OK here.

Please help check this and merge it if possible, thank you.


BUG Log:
```
code@code:~$ sudo smcroutectl add ens36 192.168.3.21 225.0.0.1 ens33
code@code:~$ sudo smcroutectl 
                                                                                                                                                                                                                                         
(*,G) Template Rules
ROUTE (S,G)                                IIF    OIFS                                                                                                                                                                                   
(*, 225.0.0.1)                             ens36 
                                                                                                                                                                                                                                         
(S,G) Rules
ROUTE (S,G)                                IIF    OIFS                                                                                                                                                                                   
(192.168.3.21, 225.0.0.1)                  ens36  ens33
                                                                                                                                                                                                                                         
Kernel MFC Table
ROUTE (S,G)                                IIF    OIFS                                                                                                                                                                                   
(192.168.3.21, 225.0.0.1)                  ens36  ens33
(192.168.248.1, 239.255.255.250)           ens33 
(192.168.23.1, 239.255.255.250)            ens36 

code@code:~$ ip mroute 
(192.168.248.1,239.255.255.250)  Iif: ens33       State: resolved
(192.168.23.1,239.255.255.250)   Iif: ens36       State: resolved
(192.168.3.21,225.0.0.1)         Iif: ens36      Oifs: ens33  State: resolved        //this would be replaced
code@code:~$ sudo smcroutectl add ens38 192.168.3.21 225.0.0.1 ens33
code@code:~$ sudo smcroutectl 
                                                                                                                                                                                                                                         
(*,G) Template Rules
ROUTE (S,G)                                IIF    OIFS                                                                                                                                                                                   
(*, 225.0.0.1)                             ens36 
                                                                                                                                                                                                                                         
(S,G) Rules
ROUTE (S,G)                                IIF    OIFS                                                                                                                                                                                   
(192.168.3.21, 225.0.0.1)                  ens36  ens33
(192.168.3.21, 225.0.0.1)                  ens38  ens33
                                                                                                                                                                                                                                         
Kernel MFC Table
ROUTE (S,G)                                IIF    OIFS                                                                                                                                                                                   
(192.168.3.21, 225.0.0.1)                  ens36  ens33
(192.168.3.21, 225.0.0.1)                  ens38  ens33
(192.168.248.1, 239.255.255.250)           ens33 
(192.168.23.1, 239.255.255.250)            ens36 

code@code:~$ ip mroute 
(192.168.3.21,225.0.0.1)         Iif: ens38      Oifs: ens33  State: resolved      //Not added, replaced the ens36 route.
(192.168.23.1,239.255.255.250)   Iif: ens36       State: resolved
(192.168.248.1,239.255.255.250)  Iif: ens33       State: resolved
code@code:~$ 
```

Kernel code(ipmr.c)
```
int ip_mroute_setsockopt(struct sock *sk, int optname, sockptr_t optval,
			 unsigned int optlen)
{
...
	case MRT_ADD_MFC:
	case MRT_DEL_MFC:
		parent = -1;        //lost NIC info here
		fallthrough;
	case MRT_ADD_MFC_PROXY:
	case MRT_DEL_MFC_PROXY:
		if (optlen != sizeof(mfc)) {
			ret = -EINVAL;
			break;
		}
		if (copy_from_sockptr(&mfc, optval, sizeof(mfc))) {
			ret = -EFAULT;
			break;
		}
		if (parent == 0)
			parent = mfc.mfcc_parent;
		if (optname == MRT_DEL_MFC || optname == MRT_DEL_MFC_PROXY)
			ret = ipmr_mfc_delete(mrt, &mfc, parent);
		else
			ret = ipmr_mfc_add(net, mrt, &mfc,
					   sk == rtnl_dereference(mrt->mroute_sk),
					   parent);
		break;
...
}
```