### PR TITLE
Fix build failures with glibc >= 2.43

### DIFF
--- a/src/smcroutectl.c
+++ b/src/smcroutectl.c
@@ -42,7 +42,7 @@ static const char version_info[] = PACKAGE_NAME " v" PACKAGE_VERSION;
 
 static char *ident = PACKAGE;
 static char *sock_file = NULL;
-static char *prognm = NULL;
+static const char *prognm = NULL;
 static int   heading = 1;
 static int   detail = 0;
 static int   plain = 0;
@@ -490,15 +490,15 @@ static int batch(void)
 	return rc;
 }
 
-static char *progname(const char *arg0)
+static const char *progname(const char *arg0)
 {
-	char *nm;
+	const char *nm;
 
 	nm = strrchr(arg0, '/');
 	if (nm)
 		nm++;
 	else
-		nm = (char *)arg0;
+		nm = arg0;
 
 	return nm;
 }

--- a/src/smcrouted.c
+++ b/src/smcrouted.c
@@ -56,7 +56,7 @@ int table_id   = 0;
 
 char *script    = NULL;
 char *ident     = PACKAGE;
-char *prognm    = NULL;
+const char *prognm    = NULL;
 char *pid_file  = NULL;
 char *conf_file = NULL;
 char *sock_file = NULL;
@@ -335,15 +335,15 @@ static int usage(int code)
 	return code;
 }
 
-static char *progname(const char *arg0)
+static const char *progname(const char *arg0)
 {
-	char *nm;
+	const char *nm;
 
 	nm = strrchr(arg0, '/');
 	if (nm)
 		nm++;
 	else
-		nm = (char *)arg0;
+		nm = arg0;
 
 	return nm;
 }


### PR DESCRIPTION
This fixes build failures that have glibc 2.43 installed as it is currently available in Debian experimental:

smcroute fails to build from source with glibc 2.43, currently in experimental. From the build log:

| smcrouted.c: In function ‘progname’:
| smcrouted.c:342:12: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
|   342 |         nm = strrchr(arg0, '/');
|       |            ^
| smcroutectl.c: In function ‘progname’:
| smcroutectl.c:497:12: error: assignment discards ‘const’ qualifier from pointer target type [-Werror=discarded-qualifiers]
|   497 |         nm = strrchr(arg0, '/');
|       |            ^
| cc1: all warnings being treated as errors
| make[3]: *** [Makefile:513: smcrouted-smcrouted.o] Error 1
| make[3]: *** Waiting for unfinished jobs....
| cc1: all warnings being treated as errors
| make[3]: *** [Makefile:499: smcroutectl-smcroutectl.o] Error 1
| make[3]: Leaving directory '/build/reproducible-path/smcroute-2.5.7/src'
| make[2]: *** [Makefile:505: all-recursive] Error 1
| make[2]: Leaving directory '/build/reproducible-path/smcroute-2.5.7'
| make[1]: *** [Makefile:367: all] Error 2
| make[1]: Leaving directory '/build/reproducible-path/smcroute-2.5.7'
| dh_auto_build: error: make -j128 returned exit code 2
| make: *** [debian/rules:25: binary] Error 25
| dpkg-buildpackage: error: debian/rules binary subprocess failed with exit status 2

The full build log is available here [1].

This was initially reported by Aurelien Jarno as Debian bug #1128751 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1128751

The issue is due to ISO C23 declaration of bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr, which now returns a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type [2].

The commit fixes the build failure by using const-qualified char pointers. This works also in older build environments as they are used as read-only variables anyways.

Regards,
Micha

[1] https://people.debian.org/~ema/glibc-2.43-rebuilds/output-1/smcroute_arm64.build
[2] https://sourceware.org/git/?p=glibc.git;a=blob;f=NEWS;h=e271fb2e4d76903c77a302aaec1ca22ce31027d0;hb=f762ccf84f122d1354f103a151cba8bde797d521#l19